### PR TITLE
Added initial work on Refined Relocation compat

### DIFF
--- a/src/api/java/com/dynious/refinedrelocation/api/APIUtils.java
+++ b/src/api/java/com/dynious/refinedrelocation/api/APIUtils.java
@@ -1,0 +1,121 @@
+package com.dynious.refinedrelocation.api;
+
+import com.dynious.refinedrelocation.api.filter.IFilterGUI;
+import com.dynious.refinedrelocation.api.relocator.IItemRelocator;
+import com.dynious.refinedrelocation.api.relocator.IRelocatorModule;
+import com.dynious.refinedrelocation.api.tileentity.IFilterTileGUI;
+import com.dynious.refinedrelocation.api.tileentity.handlers.ISortingInventoryHandler;
+import com.dynious.refinedrelocation.api.tileentity.handlers.ISortingMemberHandler;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.world.World;
+import net.minecraftforge.common.util.ForgeDirection;
+
+public final class APIUtils
+{
+    private static IAPIHandler apiHandler;
+
+    static
+    {
+        try
+        {
+            Class c = Class.forName("com.dynious.refinedrelocation.APIHandler");
+            apiHandler = (IAPIHandler) c.getField("instance").get(c);
+        } catch (Throwable e)
+        {
+            e.printStackTrace();
+        }
+    }
+
+    /**
+     * Opens the Filtering GUI for the TileEntity at the given position.
+     * The TileEntity should implement IFilterTileGUI.
+     */
+    public static void openFilteringGUI(EntityPlayer entityPlayer, World world, int x, int y, int z)
+    {
+        entityPlayer.openGui(apiHandler.getModInstance(), apiHandler.getFilteringGUIID(), world, x, y, z);
+    }
+
+    /**
+     * Creates a new instance of the standard IFilterGUI used for Sorting Chests & Filtered BlockExtenders/Buffers etc.
+     * If you want the IFilterGUI settings to be saved call writeToNBT(...) and readFromNBT(...).
+     *
+     * @return a new instance of the standard IFilterGUI
+     */
+    public static IFilterGUI createStandardFilter(IFilterTileGUI filterTile)
+    {
+        return apiHandler.createStandardFilter(filterTile);
+    }
+
+    /**
+     * Creates a new SortingMemberHandler instance. Use with ISortingMember implementers.
+     *
+     * @param owner The TileEntity this SortingMemberHandler will be used with.
+     * @return a new SortingMemberHandler instance.
+     */
+    public static ISortingMemberHandler createSortingMemberHandler(TileEntity owner)
+    {
+        return apiHandler.createSortingMemberHandler(owner);
+    }
+
+    /**
+     * Creates a new SortingInventoryHandler instance. Use with ISortingInventory implementers.
+     *
+     * @param owner The TileEntity this SortingInventoryHandler will be used with.
+     * @return a new SortingInventoryHandler instance.
+     */
+    public static ISortingInventoryHandler createSortingInventoryHandler(TileEntity owner)
+    {
+        return apiHandler.createSortingInventoryHandler(owner);
+    }
+
+    /**
+     * Registers a module for attachment to relocators. To correctly save the module your
+     * module MUST be registered using this.
+     *
+     * @param identifier The identifier of this module
+     * @param clazz      The class of this module
+     */
+    public static void registerRelocatorModule(String identifier, Class<? extends IRelocatorModule> clazz) throws IllegalArgumentException
+    {
+        apiHandler.registerRelocatorModule(identifier, clazz);
+    }
+
+    /**
+     * Will open a GUI for the module by calling the getGUI() and getContainer() methods in your module.
+     *
+     * @param relocator The identifier of this module
+     * @param player    The Player that the GUI should open for
+     * @param side      The side of the module that should open a GUI
+     */
+    public static void openRelocatorModuleGUI(IItemRelocator relocator, EntityPlayer player, int side)
+    {
+        apiHandler.openRelocatorModuleGUI(relocator, player, side);
+    }
+
+    /**
+     * Will register a class of an item that will be able to inserted into the toolbox.
+     * This class can also be a parent class or interface of this item.
+     *
+     * @param clazz The class, parent class or interface of the item to be added to the toolbox
+     */
+    public static void registerToolboxClazz(Class clazz)
+    {
+        apiHandler.registerToolboxClazz(clazz);
+    }
+
+    /**
+     * Utility method to insert items into a TileEntity (IInventory / IItemDuct etc.)
+     *
+     * @param tile TileEntity to insert into
+     * @param itemStack ItemStack to insert
+     * @param side Side to insert into
+     * @param simulate Simulate insertion (don't actually add it, just return when would happen)
+     * @return The ItemStack that was unable to be added
+     */
+    public static ItemStack insert(TileEntity tile, ItemStack itemStack, ForgeDirection side, boolean simulate)
+    {
+        return apiHandler.insert(tile, itemStack, side, simulate);
+    }
+}

--- a/src/api/java/com/dynious/refinedrelocation/api/IAPIHandler.java
+++ b/src/api/java/com/dynious/refinedrelocation/api/IAPIHandler.java
@@ -1,0 +1,33 @@
+package com.dynious.refinedrelocation.api;
+
+import com.dynious.refinedrelocation.api.filter.IFilterGUI;
+import com.dynious.refinedrelocation.api.relocator.IItemRelocator;
+import com.dynious.refinedrelocation.api.relocator.IRelocatorModule;
+import com.dynious.refinedrelocation.api.tileentity.IFilterTileGUI;
+import com.dynious.refinedrelocation.api.tileentity.handlers.ISortingInventoryHandler;
+import com.dynious.refinedrelocation.api.tileentity.handlers.ISortingMemberHandler;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraftforge.common.util.ForgeDirection;
+
+public interface IAPIHandler
+{
+    public Object getModInstance();
+
+    public int getFilteringGUIID();
+
+    public IFilterGUI createStandardFilter(IFilterTileGUI filterTile);
+
+    public ISortingMemberHandler createSortingMemberHandler(TileEntity owner);
+
+    public ISortingInventoryHandler createSortingInventoryHandler(TileEntity owner);
+
+    public void registerRelocatorModule(String identifier, Class<? extends IRelocatorModule> clazz) throws IllegalArgumentException;
+
+    public void openRelocatorModuleGUI(IItemRelocator relocator, EntityPlayer player, int side);
+
+    public void registerToolboxClazz(Class clazz);
+
+    public ItemStack insert(TileEntity tile, ItemStack itemStack, ForgeDirection side, boolean simulate);
+}

--- a/src/api/java/com/dynious/refinedrelocation/api/ModObjects.java
+++ b/src/api/java/com/dynious/refinedrelocation/api/ModObjects.java
@@ -1,0 +1,37 @@
+package com.dynious.refinedrelocation.api;
+
+import net.minecraft.item.ItemStack;
+
+public class ModObjects
+{
+    /* Blocks */
+    public static ItemStack blockExtender;
+    public static ItemStack advancedBlockExtender;
+    public static ItemStack filteredBlockExtender;
+    public static ItemStack advancedFilteredBlockExtender;
+    public static ItemStack wirelessBlockExtender;
+    public static ItemStack buffer;
+    public static ItemStack advancedBuffer;
+    public static ItemStack filteredBuffer;
+    public static ItemStack sortingChest;
+    public static ItemStack sortingConnector;
+    public static ItemStack sortingInterface;
+    public static ItemStack sortingImporter;
+    public static ItemStack filteringHopper;
+    public static ItemStack relocationPortal;
+    public static ItemStack relocationController;
+    public static ItemStack powerLimiter;
+    public static ItemStack relocator;
+
+    /* Items */
+    public static ItemStack linker;
+    public static ItemStack sortingUpgrade;
+    public static ItemStack playerRelocator;
+    public static ItemStack relocatorModule;
+    public static ItemStack toolbox;
+
+    /* Mod Dependant Blocks (does not include metadata variants)*/
+    public static ItemStack sortingIronChest;
+    public static ItemStack sortingBarrel;
+    public static ItemStack sortingAlchemicalChest;
+}

--- a/src/api/java/com/dynious/refinedrelocation/api/filter/IFilter.java
+++ b/src/api/java/com/dynious/refinedrelocation/api/filter/IFilter.java
@@ -1,0 +1,8 @@
+package com.dynious.refinedrelocation.api.filter;
+
+import net.minecraft.item.ItemStack;
+
+public interface IFilter
+{
+    public boolean passesFilter(ItemStack itemStack);
+}

--- a/src/api/java/com/dynious/refinedrelocation/api/filter/IFilterGUI.java
+++ b/src/api/java/com/dynious/refinedrelocation/api/filter/IFilterGUI.java
@@ -1,0 +1,30 @@
+package com.dynious.refinedrelocation.api.filter;
+
+import net.minecraft.nbt.NBTTagCompound;
+
+import java.util.List;
+
+public interface IFilterGUI extends IFilter
+{
+    public int getSize();
+
+    public void setValue(int place, boolean value);
+
+    public boolean getValue(int place);
+
+    public String getName(int place);
+
+    public boolean isBlacklisting();
+
+    public void setBlacklists(boolean blacklists);
+
+    public List<String> getWAILAInformation(NBTTagCompound compound);
+
+    public String getUserFilter();
+
+    public void setUserFilter(String userFilter);
+
+    public void writeToNBT(NBTTagCompound compound);
+
+    public void readFromNBT(NBTTagCompound compound);
+}

--- a/src/api/java/com/dynious/refinedrelocation/api/item/IItemRelocatorModule.java
+++ b/src/api/java/com/dynious/refinedrelocation/api/item/IItemRelocatorModule.java
@@ -1,0 +1,9 @@
+package com.dynious.refinedrelocation.api.item;
+
+import com.dynious.refinedrelocation.api.relocator.IRelocatorModule;
+import net.minecraft.item.ItemStack;
+
+public interface IItemRelocatorModule
+{
+    public IRelocatorModule getRelocatorModule(ItemStack stack);
+}

--- a/src/api/java/com/dynious/refinedrelocation/api/package-info.java
+++ b/src/api/java/com/dynious/refinedrelocation/api/package-info.java
@@ -1,0 +1,3 @@
+@API(apiVersion = "1.0.0", owner = "RefinedRelocation", provides = "RefinedRelocationAPI") package com.dynious.refinedrelocation.api;
+
+import cpw.mods.fml.common.API;

--- a/src/api/java/com/dynious/refinedrelocation/api/relocator/IItemRelocator.java
+++ b/src/api/java/com/dynious/refinedrelocation/api/relocator/IItemRelocator.java
@@ -1,0 +1,23 @@
+package com.dynious.refinedrelocation.api.relocator;
+
+import net.minecraft.item.ItemStack;
+import net.minecraft.tileentity.TileEntity;
+
+public interface IItemRelocator
+{
+    public TileEntity getTileEntity();
+
+    public IRelocatorModule getRelocatorModule(int side);
+
+    public ItemStack insert(ItemStack itemStack, int side, boolean simulate);
+
+    public boolean getRedstoneState();
+
+    public TileEntity[] getConnectedInventories();
+
+    public IItemRelocator[] getConnectedRelocators();
+
+    public boolean connectsToSide(int side);
+
+    public boolean isStuffedOnSide(int side);
+}

--- a/src/api/java/com/dynious/refinedrelocation/api/relocator/IRelocatorModule.java
+++ b/src/api/java/com/dynious/refinedrelocation/api/relocator/IRelocatorModule.java
@@ -1,0 +1,62 @@
+package com.dynious.refinedrelocation.api.relocator;
+
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+import net.minecraft.client.gui.GuiScreen;
+import net.minecraft.client.renderer.texture.IIconRegister;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.inventory.Container;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.IIcon;
+
+import java.util.List;
+
+public interface IRelocatorModule
+{
+    public void init(IItemRelocator relocator, int side);
+
+    public boolean onActivated(IItemRelocator relocator, EntityPlayer player, int side, ItemStack stack);
+
+    public void onUpdate(IItemRelocator relocator, int side);
+
+    public ItemStack outputToSide(IItemRelocator relocator, int side, TileEntity inventory, ItemStack stack, boolean simulate);
+
+    public boolean isItemDestination();
+
+    public ItemStack receiveItemStack(IItemRelocator relocator, int side, ItemStack stack, boolean input, boolean simulate);
+
+    public void onRedstonePowerChange(boolean isPowered);
+
+    public boolean connectsToRedstone();
+
+    public int strongRedstonePower(int side);
+
+    @SideOnly(Side.CLIENT)
+    public GuiScreen getGUI(IItemRelocator relocator, int side, EntityPlayer player);
+
+    public Container getContainer(IItemRelocator relocator, int side, EntityPlayer player);
+
+    public boolean passesFilter(IItemRelocator relocator, int side, ItemStack stack, boolean input, boolean simulate);
+
+    public void readFromNBT(IItemRelocator relocator, int side, NBTTagCompound compound);
+
+    public void writeToNBT(IItemRelocator relocator, int side, NBTTagCompound compound);
+
+    public void readClientData(IItemRelocator relocator, int side, NBTTagCompound compound);
+
+    public void writeClientData(IItemRelocator relocator, int side, NBTTagCompound compound);
+
+    public List<ItemStack> getDrops(IItemRelocator relocator, int side);
+
+    @SideOnly(Side.CLIENT)
+    public IIcon getIcon(IItemRelocator relocator, int side);
+
+    @SideOnly(Side.CLIENT)
+    public void registerIcons(IIconRegister register);
+
+    public String getDisplayName();
+
+    public List<String> getWailaInformation(NBTTagCompound nbtData);
+}

--- a/src/api/java/com/dynious/refinedrelocation/api/relocator/RelocatorModuleBase.java
+++ b/src/api/java/com/dynious/refinedrelocation/api/relocator/RelocatorModuleBase.java
@@ -1,0 +1,137 @@
+package com.dynious.refinedrelocation.api.relocator;
+
+import com.dynious.refinedrelocation.api.APIUtils;
+import cpw.mods.fml.relauncher.Side;
+import cpw.mods.fml.relauncher.SideOnly;
+import net.minecraft.client.gui.GuiScreen;
+import net.minecraft.client.renderer.texture.IIconRegister;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.inventory.Container;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.IIcon;
+import net.minecraftforge.common.util.ForgeDirection;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public abstract class RelocatorModuleBase implements IRelocatorModule
+{
+    @Override
+    public void init(IItemRelocator relocator, int side)
+    {
+    }
+
+    @Override
+    public boolean onActivated(IItemRelocator relocator, EntityPlayer player, int side, ItemStack stack)
+    {
+        return false;
+    }
+
+    @Override
+    public void onUpdate(IItemRelocator relocator, int side)
+    {
+    }
+
+    @Override
+    public ItemStack outputToSide(IItemRelocator relocator, int side, TileEntity inventory, ItemStack stack, boolean simulate)
+    {
+        return APIUtils.insert(inventory, stack, ForgeDirection.getOrientation(side).getOpposite(), simulate);
+    }
+
+    @Override
+    public boolean isItemDestination()
+    {
+        return false;
+    }
+
+    @Override
+    public ItemStack receiveItemStack(IItemRelocator relocator, int side, ItemStack stack, boolean input, boolean simulate)
+    {
+        return stack;
+    }
+
+    @Override
+    public void onRedstonePowerChange(boolean isPowered)
+    {
+    }
+
+    @Override
+    public int strongRedstonePower(int side)
+    {
+        return 0;
+    }
+
+    @Override
+    public boolean connectsToRedstone()
+    {
+        return false;
+    }
+
+    @Override
+    @SideOnly(Side.CLIENT)
+    public GuiScreen getGUI(IItemRelocator relocator, int side, EntityPlayer player)
+    {
+        return null;
+    }
+
+    @Override
+    public Container getContainer(IItemRelocator relocator, int side, EntityPlayer player)
+    {
+        return null;
+    }
+
+    @Override
+    public boolean passesFilter(IItemRelocator relocator, int side, ItemStack stack, boolean input, boolean simulate)
+    {
+        return true;
+    }
+
+    @Override
+    public void readFromNBT(IItemRelocator relocator, int side, NBTTagCompound compound)
+    {
+    }
+
+    @Override
+    public void writeToNBT(IItemRelocator relocator, int side, NBTTagCompound compound)
+    {
+    }
+
+    @Override
+    public void readClientData(IItemRelocator relocator, int side, NBTTagCompound compound)
+    {
+    }
+
+    @Override
+    public void writeClientData(IItemRelocator relocator, int side, NBTTagCompound compound)
+    {
+    }
+
+    @Override
+    public abstract List<ItemStack> getDrops(IItemRelocator relocator, int side);
+
+    @Override
+    @SideOnly(Side.CLIENT)
+    public abstract IIcon getIcon(IItemRelocator relocator, int side);
+
+    @Override
+    @SideOnly(Side.CLIENT)
+    public void registerIcons(IIconRegister register)
+    {
+
+    }
+
+    @Override
+    public String getDisplayName()
+    {
+        return "";
+    }
+
+    @Override
+    public List<String> getWailaInformation(NBTTagCompound nbtData)
+    {
+        List<String> information = new ArrayList<String>();
+        return information;
+    }
+}

--- a/src/api/java/com/dynious/refinedrelocation/api/tileentity/IFilterTile.java
+++ b/src/api/java/com/dynious/refinedrelocation/api/tileentity/IFilterTile.java
@@ -1,0 +1,8 @@
+package com.dynious.refinedrelocation.api.tileentity;
+
+import com.dynious.refinedrelocation.api.filter.IFilter;
+
+public interface IFilterTile
+{
+    public IFilter getFilter();
+}

--- a/src/api/java/com/dynious/refinedrelocation/api/tileentity/IFilterTileGUI.java
+++ b/src/api/java/com/dynious/refinedrelocation/api/tileentity/IFilterTileGUI.java
@@ -1,0 +1,16 @@
+package com.dynious.refinedrelocation.api.tileentity;
+
+import com.dynious.refinedrelocation.api.filter.IFilterGUI;
+import net.minecraft.tileentity.TileEntity;
+
+/**
+ * If your TileEntity implements the interface it will be able to open the Filtering GUI.
+ */
+public interface IFilterTileGUI extends IFilterTile
+{
+    public IFilterGUI getFilter();
+
+    public TileEntity getTileEntity();
+
+    public void onFilterChanged();
+}

--- a/src/api/java/com/dynious/refinedrelocation/api/tileentity/IGridMember.java
+++ b/src/api/java/com/dynious/refinedrelocation/api/tileentity/IGridMember.java
@@ -1,0 +1,16 @@
+package com.dynious.refinedrelocation.api.tileentity;
+
+import com.dynious.refinedrelocation.api.tileentity.handlers.IGridMemberHandler;
+
+/**
+ * Base class, DO NOT USE THIS!
+ */
+public interface IGridMember
+{
+    /**
+     * This should return the ISortingMemberHandler of this tile. It cannot be null.
+     *
+     * @return The GridMemberHandler of this tile
+     */
+    public IGridMemberHandler getHandler();
+}

--- a/src/api/java/com/dynious/refinedrelocation/api/tileentity/IInventoryChangeListener.java
+++ b/src/api/java/com/dynious/refinedrelocation/api/tileentity/IInventoryChangeListener.java
@@ -1,0 +1,10 @@
+package com.dynious.refinedrelocation.api.tileentity;
+
+public interface IInventoryChangeListener
+{
+    /**
+     * This will be called when a change is made in one of the inventories in the Grid of the TileEntity
+     * is in.
+     */
+    public void onInventoryChanged();
+}

--- a/src/api/java/com/dynious/refinedrelocation/api/tileentity/ISortingInventory.java
+++ b/src/api/java/com/dynious/refinedrelocation/api/tileentity/ISortingInventory.java
@@ -1,0 +1,77 @@
+package com.dynious.refinedrelocation.api.tileentity;
+
+import com.dynious.refinedrelocation.api.tileentity.handlers.ISortingInventoryHandler;
+import net.minecraft.inventory.IInventory;
+import net.minecraft.item.ItemStack;
+
+/**
+ * This extends the {@link ISortingMember} interface.
+ * Tile that implement this interface will be part of the Sorting Network
+ * and their inventory will actively be used in the network.
+ * The Filter set in the IFilterTile interface will be used as the filter.
+ * <p/>
+ * Make sure you call all required methods of {@link ISortingMember} as well as
+ * setInventorySlotContents(...) when this is called in your tile.
+ * <p/>
+ * Override markDirty() in your tile and call getHandler().onInventoryChange()!
+ * This will make sure the Sorting System knows there have been changes in your inventory.
+ * Only call
+ * <p/>
+ * To open the Filtering GUI for this TileEntity also implement {@link IFilterTileGUI}).
+ * <p/>
+ * Automatically syncs the inventory to all players in a 5 block radius.
+ */
+public interface ISortingInventory extends ISortingMember, IInventory, IFilterTile
+{
+    /**
+     * This should return the SortingInventoryHandler of this tile. It cannot be null.
+     * Create a new SortingMemberHandler instance using APIUtils.createSortingInventoryHandler(...)
+     *
+     * @return The SortingInventoryHandler of this tile
+     */
+    public ISortingInventoryHandler getHandler();
+
+    /**
+     * Forcibly sets an ItemStack to the slotIndex
+     *
+     * @param itemStack The stack to add
+     * @param slotIndex The slot index to add the ItemStack in
+     * @return Were we able to add the ItemStack?
+     */
+    public boolean putStackInSlot(ItemStack itemStack, int slotIndex);
+
+    /**
+     * This should try to add the ItemStack to the inventory of this TileEntity
+     *
+     * @param itemStack The stack that should be put in the inventory
+     * @param simulate  Simulate the insertion of items (only return result, no action)
+     * @return The remaining ItemStack after trying to put the ItemStack in the Inventory
+     */
+    public ItemStack putInInventory(ItemStack itemStack, boolean simulate);
+
+    /**
+     * The Sorting System will try to put items in the highest priority inventory.
+     * Blacklisting Chests have a low standard Priority, while whitelisting chests have a normal standard priority.
+     * Barrels have the high standard priority, because they only accept one type of item.
+     * This will not affect items that do not pass the Filter.
+     *
+     * @return The Priority of this ISortingInventory
+     */
+    public Priority getPriority();
+
+    /**
+     * Sets the priority of a block to a new value.
+     *
+     * @param priority The new priority of this tile
+     */
+    public void setPriority(Priority priority);
+
+    enum Priority
+    {
+        HIGH,
+        NORMAL_HIGH,
+        NORMAL,
+        NORMAL_LOW,
+        LOW
+    }
+}

--- a/src/api/java/com/dynious/refinedrelocation/api/tileentity/ISortingMember.java
+++ b/src/api/java/com/dynious/refinedrelocation/api/tileentity/ISortingMember.java
@@ -1,0 +1,20 @@
+package com.dynious.refinedrelocation.api.tileentity;
+
+
+import com.dynious.refinedrelocation.api.tileentity.handlers.ISortingMemberHandler;
+
+/**
+ * This is the interface that will make your TileEntity part of the Sorting Network.
+ * <p/>
+ * Make sure you call the onTileAdded() and onTileRemoved() at the right time.
+ */
+public interface ISortingMember extends IGridMember
+{
+    /**
+     * This should return the ISortingMemberHandler of this tile. It cannot be null.
+     * Create a new SortingMemberHandler instance using APIUtils.createSortingMemberHandler(...)
+     *
+     * @return The SortingMemberHandler of this tile
+     */
+    public ISortingMemberHandler getHandler();
+}

--- a/src/api/java/com/dynious/refinedrelocation/api/tileentity/ISpecialSortingInventory.java
+++ b/src/api/java/com/dynious/refinedrelocation/api/tileentity/ISpecialSortingInventory.java
@@ -1,0 +1,23 @@
+package com.dynious.refinedrelocation.api.tileentity;
+
+import com.dynious.refinedrelocation.api.tileentity.grid.SpecialLocalizedStack;
+
+public interface ISpecialSortingInventory extends ISortingInventory
+{
+    /**
+     * Returns a SpecialLocalizedStack for the giving slot, which will enable altering the amount of items
+     * in your inventory without altering the stack size of the ItemStack in the slot.
+     *
+     * @param slot The slot this stack is in.
+     * @return The new SpecialLocalizedStack for this slot.
+     */
+    public SpecialLocalizedStack getLocalizedStackInSlot(int slot);
+
+    /**
+     * This should alter the amount of items in your inventory in the given slot.
+     *
+     * @param slot The slot that should change size.
+     * @param alteration The change (positive is addition, negative is removal).
+     */
+    public void alterStackSize(int slot, int alteration);
+}

--- a/src/api/java/com/dynious/refinedrelocation/api/tileentity/grid/IGrid.java
+++ b/src/api/java/com/dynious/refinedrelocation/api/tileentity/grid/IGrid.java
@@ -1,0 +1,39 @@
+package com.dynious.refinedrelocation.api.tileentity.grid;
+
+import com.dynious.refinedrelocation.api.tileentity.handlers.IGridMemberHandler;
+
+import java.util.List;
+
+public interface IGrid
+{
+    /**
+     * Adds a member to the list of members
+     *
+     * @param member Member to be added
+     */
+    public void addMember(IGridMemberHandler member);
+
+    /**
+     * Removes a member from the list of members
+     *
+     * @param member Member to be removed
+     */
+    public void removeMember(IGridMemberHandler member);
+
+    /**
+     * Sets grid of all members to null and deletes the member list
+     */
+    public void resetMembers();
+
+    /**
+     * Returns all members of this grid
+     */
+    public List<IGridMemberHandler> getMembers();
+
+    /**
+     * Merges this grid into the give grid
+     *
+     * @param grid The new Grid for this Grid should merge with
+     */
+    public void mergeToGrid(IGrid grid);
+}

--- a/src/api/java/com/dynious/refinedrelocation/api/tileentity/grid/ISortingGrid.java
+++ b/src/api/java/com/dynious/refinedrelocation/api/tileentity/grid/ISortingGrid.java
@@ -1,0 +1,31 @@
+package com.dynious.refinedrelocation.api.tileentity.grid;
+
+
+import net.minecraft.item.ItemStack;
+import net.minecraft.tileentity.TileEntity;
+
+import java.util.List;
+
+public interface ISortingGrid extends IGrid
+{
+    /**
+     * Filters an ItemStack to all members of the SortingMember group
+     *
+     * @param itemStack The ItemStack to be filtered to all childs and this SortingMember
+     * @param simulate  Simulate the insertion of items (only return result, no action)
+     * @return The ItemStack that was not able to fit in any ISortingInventory
+     */
+    public ItemStack filterStackToGroup(ItemStack itemStack, TileEntity requester, int slot, boolean simulate);
+
+    /**
+     * Returns a List of all ItemStacks present in the Grid
+     *
+     * @return List of all ItemStacks in the Grid
+     */
+    public List<LocalizedStack> getItemsInGrid();
+
+    /**
+     * Should be called when a change is made in one of the members on the Sorting System.
+     */
+    public void onInventoryChange();
+}

--- a/src/api/java/com/dynious/refinedrelocation/api/tileentity/grid/LocalizedStack.java
+++ b/src/api/java/com/dynious/refinedrelocation/api/tileentity/grid/LocalizedStack.java
@@ -1,0 +1,28 @@
+package com.dynious.refinedrelocation.api.tileentity.grid;
+
+import net.minecraft.inventory.IInventory;
+import net.minecraft.item.ItemStack;
+
+public class LocalizedStack
+{
+    public final ItemStack STACK;
+    public final IInventory INVENTORY;
+    public final int SLOT;
+
+    public LocalizedStack(ItemStack stack, IInventory inventory, int slot)
+    {
+        this.STACK = stack;
+        this.INVENTORY = inventory;
+        this.SLOT = slot;
+    }
+
+    public int getStackSize()
+    {
+        return STACK.stackSize;
+    }
+
+    public void alterStackSize(int alteration)
+    {
+        STACK.stackSize += alteration;
+    }
+}

--- a/src/api/java/com/dynious/refinedrelocation/api/tileentity/grid/SpecialLocalizedStack.java
+++ b/src/api/java/com/dynious/refinedrelocation/api/tileentity/grid/SpecialLocalizedStack.java
@@ -1,0 +1,28 @@
+package com.dynious.refinedrelocation.api.tileentity.grid;
+
+import com.dynious.refinedrelocation.api.tileentity.ISpecialSortingInventory;
+import net.minecraft.item.ItemStack;
+
+public class SpecialLocalizedStack extends LocalizedStack
+{
+    private int size;
+
+    public SpecialLocalizedStack(ItemStack stack, ISpecialSortingInventory inventory, int slot, int size)
+    {
+        super(stack, inventory, slot);
+        this.size = size;
+    }
+
+    @Override
+    public int getStackSize()
+    {
+        return size;
+    }
+
+    @Override
+    public void alterStackSize(int alteration)
+    {
+        ((ISpecialSortingInventory) INVENTORY).alterStackSize(SLOT, alteration);
+        size += alteration;
+    }
+}

--- a/src/api/java/com/dynious/refinedrelocation/api/tileentity/handlers/IGridMemberHandler.java
+++ b/src/api/java/com/dynious/refinedrelocation/api/tileentity/handlers/IGridMemberHandler.java
@@ -1,0 +1,43 @@
+package com.dynious.refinedrelocation.api.tileentity.handlers;
+
+import com.dynious.refinedrelocation.api.tileentity.grid.IGrid;
+import net.minecraft.tileentity.TileEntity;
+
+public interface IGridMemberHandler
+{
+    /**
+     * Get the owner of this Handler
+     *
+     * @return The TileEntity this Handler is linked to
+     */
+    public TileEntity getOwner();
+
+    /**
+     * Should be called on first tick from its TileEntity
+     */
+    public void onTileAdded();
+
+    /**
+     * Should be called by invalidate() and onChunkUnload() from its TileEntity
+     */
+    public void onTileRemoved();
+
+    /**
+     * Get the Grid of this GridMember
+     *
+     * @return The Grid of this GridMember
+     */
+    public IGrid getGrid();
+
+    /**
+     * Sets the Grid of a GridMember
+     *
+     * @param newLeader The new Grid for this GridMember
+     */
+    public void setGrid(IGrid newLeader);
+
+    /**
+     * @return Boolean if the GridMember can join a group
+     */
+    public boolean canJoinGroup();
+}

--- a/src/api/java/com/dynious/refinedrelocation/api/tileentity/handlers/ISortingInventoryHandler.java
+++ b/src/api/java/com/dynious/refinedrelocation/api/tileentity/handlers/ISortingInventoryHandler.java
@@ -1,0 +1,17 @@
+package com.dynious.refinedrelocation.api.tileentity.handlers;
+
+import net.minecraft.item.ItemStack;
+
+public interface ISortingInventoryHandler extends ISortingMemberHandler
+{
+    /**
+     * Used when adding an item to the inventory of the TileEntity
+     * (Should be called by setInventorySlotContents(...) in the TileEntity class)
+     */
+    public void setInventorySlotContents(int par1, ItemStack itemStack);
+
+    /**
+     * Should be called when a change is made in one of the members on the Sorting System.
+     */
+    public void onInventoryChange();
+}

--- a/src/api/java/com/dynious/refinedrelocation/api/tileentity/handlers/ISortingMemberHandler.java
+++ b/src/api/java/com/dynious/refinedrelocation/api/tileentity/handlers/ISortingMemberHandler.java
@@ -1,0 +1,13 @@
+package com.dynious.refinedrelocation.api.tileentity.handlers;
+
+import com.dynious.refinedrelocation.api.tileentity.grid.ISortingGrid;
+
+public interface ISortingMemberHandler extends IGridMemberHandler
+{
+    /**
+     * Get the SortingGrid of this GridMember
+     *
+     * @return The SortingGrid of this GridMember
+     */
+    public ISortingGrid getGrid();
+}

--- a/src/main/java/com/workshop/compactstorage/block/BlockChest.java
+++ b/src/main/java/com/workshop/compactstorage/block/BlockChest.java
@@ -1,10 +1,12 @@
 package com.workshop.compactstorage.block;
 
+import com.workshop.compactstorage.compat.RefinedRelocationCompat;
 import com.workshop.compactstorage.essential.CompactStorage;
 import com.workshop.compactstorage.essential.init.StorageBlocks;
 import com.workshop.compactstorage.exception.InvalidSizeException;
 import com.workshop.compactstorage.tileentity.TileEntityChest;
 import com.workshop.compactstorage.util.EntityUtil;
+import cpw.mods.fml.common.Loader;
 import net.minecraft.block.Block;
 import net.minecraft.block.ITileEntityProvider;
 import net.minecraft.block.material.Material;
@@ -134,6 +136,11 @@ public class BlockChest extends Block implements ITileEntityProvider
                 if(name.startsWith("item.dolly.normal.empty") || name.startsWith("item.dolly.diamond.empty"))
                 {
                     return true;
+                }
+                if (Loader.isModLoaded("RefinedRelocation"))
+                {
+                    if (RefinedRelocationCompat.tryToUpgrade(player.getHeldItem(), world, x, y, z))
+                        return true;
                 }
             }
 

--- a/src/main/java/com/workshop/compactstorage/block/BlockSortingChest.java
+++ b/src/main/java/com/workshop/compactstorage/block/BlockSortingChest.java
@@ -1,0 +1,92 @@
+package com.workshop.compactstorage.block;
+
+import com.dynious.refinedrelocation.api.APIUtils;
+import com.workshop.compactstorage.compat.RefinedRelocationCompat;
+import com.workshop.compactstorage.tileentity.TileEntityChest;
+import com.workshop.compactstorage.tileentity.TileEntitySortingChest;
+import net.minecraft.block.Block;
+import net.minecraft.entity.item.EntityItem;
+import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.util.MovingObjectPosition;
+import net.minecraft.world.World;
+
+import java.util.Random;
+
+public class BlockSortingChest extends BlockChest
+{
+    public BlockSortingChest()
+    {
+        setBlockName("sortingcompactchest");
+    }
+
+    @Override
+    public boolean onBlockActivated(World world, int x, int y, int z, EntityPlayer player, int i1, float f1, float f2, float f3)
+    {
+        if (world.isRemote)
+        {
+            return true;
+        }
+
+        if (player.isSneaking())
+        {
+            APIUtils.openFilteringGUI(player, world, x, y, z);
+            return true;
+        }
+
+        return super.onBlockActivated(world, x, y, z, player, i1, f1, f2, f3);
+    }
+
+    @Override
+    public TileEntity createTileEntity(World world, int metadata)
+    {
+        return new TileEntitySortingChest();
+    }
+
+    //TODO: Maybe do this differently (this is copied from BlockChest and only changed the ItemStack Block input)
+    @Override
+    public void breakBlock(World world, int x, int y, int z, Block block, int meta)
+    {
+        TileEntityChest chest = (TileEntityChest) world.getTileEntity(x, y, z);
+
+        if(chest != null)
+        {
+            ItemStack stack = new ItemStack(RefinedRelocationCompat.sortingChest, 1);
+            Random rand = new Random();
+
+            stack.setTagCompound(new NBTTagCompound());
+
+            int invX = chest.invX;
+            int invY = chest.invY;
+            int color = chest.color;
+
+            stack.getTagCompound().setIntArray("size", new int[]{invX, invY});
+            stack.getTagCompound().setInteger("color", color);
+
+            world.spawnEntityInWorld(new EntityItem(world, x, y + 0.5f, z, stack));
+
+            for(int slot = 0; slot < chest.items.length; slot++)
+            {
+                float randX = rand.nextFloat();
+                float randZ = rand.nextFloat();
+
+                if(chest.items != null && chest.items[slot] != null) world.spawnEntityInWorld(new EntityItem(world, x + randX, y + 0.5f, z + randZ, chest.items[slot]));
+            }
+        }
+    }
+
+    //TODO: Maybe do this differently (this is copied from BlockChest and only changed the ItemStack Block input)
+    @Override
+    public ItemStack getPickBlock(MovingObjectPosition target, World world, int x, int y, int z)
+    {
+        ItemStack stack = new ItemStack(RefinedRelocationCompat.sortingChest, 1);
+        TileEntityChest chest = (TileEntityChest) world.getTileEntity(x, y, z);
+
+        stack.setTagCompound(new NBTTagCompound());
+        stack.getTagCompound().setIntArray("size", new int[] {chest.invX, chest.invY});
+
+        return stack;
+    }
+}

--- a/src/main/java/com/workshop/compactstorage/compat/RefinedRelocationCompat.java
+++ b/src/main/java/com/workshop/compactstorage/compat/RefinedRelocationCompat.java
@@ -1,0 +1,61 @@
+package com.workshop.compactstorage.compat;
+
+import com.dynious.refinedrelocation.api.ModObjects;
+import com.workshop.compactstorage.block.BlockSortingChest;
+import com.workshop.compactstorage.item.ItemBlockChest;
+import com.workshop.compactstorage.tileentity.TileEntityChest;
+import com.workshop.compactstorage.tileentity.TileEntitySortingChest;
+import cpw.mods.fml.common.registry.GameRegistry;
+import net.minecraft.block.Block;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.tileentity.TileEntity;
+import net.minecraft.world.World;
+
+public class RefinedRelocationCompat implements ICompat
+{
+    public static Block sortingChest;
+
+    @Override
+    public String modid()
+    {
+        return "RefinedRelocation";
+    }
+
+    @Override
+    public void registerCompat() throws Exception
+    {
+        sortingChest = new BlockSortingChest();
+        GameRegistry.registerBlock(sortingChest, ItemBlockChest.class, "sortingCompactChest");
+        GameRegistry.registerTileEntity(TileEntitySortingChest.class, "tileSortingChest");
+    }
+
+    public static boolean tryToUpgrade(ItemStack stack, World world, int x, int y, int z)
+    {
+        TileEntity tile = world.getTileEntity(x, y, z);
+        if (tile instanceof TileEntityChest && !(tile instanceof TileEntitySortingChest) && stack != null && stack.getItem() == ModObjects.sortingUpgrade.getItem() && stack.getItemDamage() == 0)
+        {
+            TileEntityChest chest = (TileEntityChest) tile;
+            TileEntitySortingChest sortingChestTile = new TileEntitySortingChest();
+            int meta = chest.getBlockMetadata();
+
+            NBTTagCompound compound = new NBTTagCompound();
+            chest.writeToNBT(compound);
+            sortingChestTile.readFromNBT(compound);
+
+            //Remove the TE first so we don't drop items
+            world.removeTileEntity(x, y, z);
+            // Clear the old block out
+            world.setBlockToAir(x, y, z);
+            // Force the Chest TE to reset it's knowledge of neighbouring blocks
+            // And put in our block instead
+            world.setBlock(x, y, z, sortingChest, 0, 3);
+
+            world.setTileEntity(x, y, z, sortingChestTile);
+            world.setBlockMetadataWithNotify(x, y, z, meta, 3);
+            stack.stackSize--;
+            return true;
+        }
+        return false;
+    }
+}

--- a/src/main/java/com/workshop/compactstorage/essential/CompactStorage.java
+++ b/src/main/java/com/workshop/compactstorage/essential/CompactStorage.java
@@ -3,6 +3,7 @@ package com.workshop.compactstorage.essential;
 import java.util.List;
 
 import com.workshop.compactstorage.command.CommandCompactStorage;
+import com.workshop.compactstorage.compat.RefinedRelocationCompat;
 import cpw.mods.fml.common.event.FMLServerStartingEvent;
 import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.init.Blocks;
@@ -77,6 +78,7 @@ public class CompactStorage
     	
     	if(Loader.isModLoaded("JABBA")) compat.add(new JabbaCompat());
     	if(Loader.isModLoaded("Waila")) compat.add(new WailaCompat());
+        if(Loader.isModLoaded("RefinedRelocation")) compat.add(new RefinedRelocationCompat());
     	
         try
         {

--- a/src/main/java/com/workshop/compactstorage/essential/proxy/ClientProxy.java
+++ b/src/main/java/com/workshop/compactstorage/essential/proxy/ClientProxy.java
@@ -2,11 +2,14 @@ package com.workshop.compactstorage.essential.proxy;
 
 import com.workshop.compactstorage.client.render.ChestItemRenderer;
 import com.workshop.compactstorage.client.render.TileEntityChestRenderer;
+import com.workshop.compactstorage.compat.RefinedRelocationCompat;
 import com.workshop.compactstorage.essential.handler.FirstTimeRunHandler;
 import com.workshop.compactstorage.essential.init.StorageBlocks;
 import com.workshop.compactstorage.tileentity.TileEntityChest;
+import com.workshop.compactstorage.tileentity.TileEntitySortingChest;
 import cpw.mods.fml.client.registry.ClientRegistry;
 import cpw.mods.fml.common.FMLCommonHandler;
+import cpw.mods.fml.common.Loader;
 import net.minecraft.item.ItemBlock;
 import net.minecraftforge.client.MinecraftForgeClient;
 import net.minecraftforge.common.MinecraftForge;
@@ -20,6 +23,12 @@ public class ClientProxy implements IProxy
     {
         ClientRegistry.bindTileEntitySpecialRenderer(TileEntityChest.class, new TileEntityChestRenderer());
         MinecraftForgeClient.registerItemRenderer(ItemBlock.getItemFromBlock(StorageBlocks.chest), new ChestItemRenderer());
+
+        if (Loader.isModLoaded("RefinedRelocation"))
+        {
+            ClientRegistry.bindTileEntitySpecialRenderer(TileEntitySortingChest.class, new TileEntityChestRenderer());
+            MinecraftForgeClient.registerItemRenderer(ItemBlock.getItemFromBlock(RefinedRelocationCompat.sortingChest), new ChestItemRenderer());
+        }
 
         MinecraftForge.EVENT_BUS.register(new FirstTimeRunHandler());
         FMLCommonHandler.instance().bus().register(new FirstTimeRunHandler());

--- a/src/main/java/com/workshop/compactstorage/tileentity/TileEntitySortingChest.java
+++ b/src/main/java/com/workshop/compactstorage/tileentity/TileEntitySortingChest.java
@@ -1,0 +1,174 @@
+package com.workshop.compactstorage.tileentity;
+
+import com.dynious.refinedrelocation.api.APIUtils;
+import com.dynious.refinedrelocation.api.filter.IFilterGUI;
+import com.dynious.refinedrelocation.api.tileentity.IFilterTileGUI;
+import com.dynious.refinedrelocation.api.tileentity.ISortingInventory;
+import com.dynious.refinedrelocation.api.tileentity.handlers.ISortingInventoryHandler;
+import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
+import net.minecraft.tileentity.TileEntity;
+
+public class TileEntitySortingChest extends TileEntityChest implements ISortingInventory, IFilterTileGUI
+{
+    public boolean isFirstRun = true;
+
+    private IFilterGUI filter = APIUtils.createStandardFilter(this);
+
+    private ISortingInventoryHandler sortingInventoryHandler = APIUtils.createSortingInventoryHandler(this);
+    private ISortingInventory.Priority priority = ISortingInventory.Priority.NORMAL;
+
+    @Override
+    public void updateEntity()
+    {
+        if (isFirstRun)
+        {
+            sortingInventoryHandler.onTileAdded();
+            isFirstRun = false;
+        }
+        super.updateEntity();
+    }
+
+    @Override
+    public void setInventorySlotContents(int i, ItemStack itemstack)
+    {
+        sortingInventoryHandler.setInventorySlotContents(i, itemstack);
+    }
+
+    @Override
+    public boolean putStackInSlot(ItemStack itemStack, int slotIndex)
+    {
+        if (slotIndex >= 0 && slotIndex < items.length)
+        {
+            items[slotIndex] = itemStack;
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public ItemStack putInInventory(ItemStack itemStack, boolean simulate)
+    {
+        int emptySlot = -1;
+        for (int slot = 0; slot < getSizeInventory() && itemStack != null && itemStack.stackSize > 0; ++slot)
+        {
+            if (isItemValidForSlot(slot, itemStack))
+            {
+                ItemStack itemstack1 = getStackInSlot(slot);
+
+                if (itemstack1 == null)
+                {
+                    if (simulate)
+                        return null;
+                    if (emptySlot == -1)
+                        emptySlot = slot;
+                }
+                else if (areItemStacksEqual(itemstack1, itemStack))
+                {
+                    int max = Math.min(itemStack.getMaxStackSize(), getInventoryStackLimit());
+                    if (max > itemstack1.stackSize)
+                    {
+                        int l = Math.min(itemStack.stackSize, max - itemstack1.stackSize);
+                        itemStack.stackSize -= l;
+                        if (!simulate)
+                        {
+                            itemstack1.stackSize += l;
+                            markDirty();
+                        }
+                    }
+                }
+            }
+        }
+
+        if (itemStack != null && itemStack.stackSize != 0 && emptySlot != -1)
+        {
+            items[emptySlot] = itemStack;
+            itemStack = null;
+            markDirty();
+        }
+
+        return itemStack;
+    }
+
+    /**
+     * compares ItemStack argument to the instance ItemStack; returns true if both ItemStacks are equal
+     */
+    public static boolean areItemStacksEqual(ItemStack itemStack1, ItemStack itemStack2)
+    {
+        return itemStack1 == null && itemStack2 == null || (!(itemStack1 == null || itemStack2 == null) && (itemStack1.getItem() == itemStack2.getItem() && (itemStack1.getItemDamage() == itemStack2.getItemDamage() && (!(itemStack1.stackTagCompound == null && itemStack2.stackTagCompound != null) && (itemStack1.stackTagCompound == null || itemStack1.stackTagCompound.equals(itemStack2.stackTagCompound))))));
+    }
+
+    @Override
+    public IFilterGUI getFilter()
+    {
+        return filter;
+    }
+
+    @Override
+    public TileEntity getTileEntity()
+    {
+        return this;
+    }
+
+    @Override
+    public void onFilterChanged()
+    {
+        this.markDirty();
+    }
+
+    @Override
+    public Priority getPriority()
+    {
+        return priority;
+    }
+
+    @Override
+    public void setPriority(Priority priority)
+    {
+        this.priority = priority;
+    }
+
+    @Override
+    public ISortingInventoryHandler getHandler()
+    {
+        return sortingInventoryHandler;
+    }
+
+    @Override
+    public void markDirty()
+    {
+        super.markDirty();
+        getHandler().onInventoryChange();
+    }
+
+
+    @Override
+    public void readFromNBT(NBTTagCompound compound)
+    {
+        super.readFromNBT(compound);
+        filter.readFromNBT(compound);
+        setPriority(Priority.values()[compound.getByte("priority")]);
+    }
+
+    @Override
+    public void writeToNBT(NBTTagCompound compound)
+    {
+        super.writeToNBT(compound);
+        filter.writeToNBT(compound);
+        compound.setByte("priority", (byte) priority.ordinal());
+    }
+
+    @Override
+    public void invalidate()
+    {
+        sortingInventoryHandler.onTileRemoved();
+        super.invalidate();
+    }
+
+    @Override
+    public void onChunkUnload()
+    {
+        sortingInventoryHandler.onTileRemoved();
+        super.onChunkUnload();
+    }
+}

--- a/src/main/resources/assets/compactstorage/lang/en_US.lang
+++ b/src/main/resources/assets/compactstorage/lang/en_US.lang
@@ -1,4 +1,5 @@
 tile.compactchest.name=Compact Chest
+tile.sortingcompactchest.name=Sorting Compact Chest
 tile.chestbuilder.name=Builder
 item.backpack.name=Backpack
 itemGroup.compactStorage=CompactStorage


### PR DESCRIPTION
I started with adding compatibility with Refined Relocation. In this way all chests will be upgradable with the Refined Relocation in-world upgrade, but will not be able to be crafted in the Chest Builder or other recipes. The Sorting version will also not show up in the creative menu yet. I added 2 TODOs which are basically needed enhancements.

The compat is basically 100% functional, the Sorting versions of the chests work perfectly, so everything involving the RR API in done. Only thing left to do is letting users know the Sorting versions are available (by making them craftable and adding them to the creative menu).